### PR TITLE
touchpanel_mtdev: add -lmtdev to link dependencies

### DIFF
--- a/src/touchpanel/touchpanel.c
+++ b/src/touchpanel/touchpanel.c
@@ -363,9 +363,9 @@ init_touchpanel(void)
 	int  maxX, maxY, sXres, sYres, ret = -1;
 
 #ifdef TOUCHPANEL_DEVICE
-	touchpanel_event_fd = open(TOUCHPANEL_DEVICE, O_RDWR);
+	touchpanel_event_fd = open(TOUCHPANEL_DEVICE, O_RDWR | O_NONBLOCK);
 #else
-	touchpanel_event_fd = open("/dev/input/touchscreen0", O_RDWR);
+	touchpanel_event_fd = open("/dev/input/touchscreen0", O_RDWR | O_NONBLOCK);
 #endif
 
 	if (touchpanel_event_fd < 0)

--- a/src/touchpanel_mtdev/CMakeLists.txt
+++ b/src/touchpanel_mtdev/CMakeLists.txt
@@ -18,4 +18,4 @@
 
 webos_build_nyx_module(TouchpanelMain
 		       SOURCES touchpanel.c touchpanel_common.c touchpanel_gestures.c
-		       LIBRARIES ${GLIB2_LDFLAGS} ${PMLOG_LDFLAGS} ${NYXLIB_LDFLAGS} -lrt -lpthread)
+		       LIBRARIES ${GLIB2_LDFLAGS} ${PMLOG_LDFLAGS} ${NYXLIB_LDFLAGS} ${MTDEV_LDFLAGS} -lrt -lpthread)

--- a/src/touchpanel_mtdev/touchpanel.c
+++ b/src/touchpanel_mtdev/touchpanel.c
@@ -387,7 +387,11 @@ init_touchpanel(void)
 	struct input_absinfo abs;
 	int  maxX, maxY, sXres, sYres, ret = -1;
 
+#ifdef TOUCHPANEL_DEVICE
+	touchpanel_event_fd = open(TOUCHPANEL_DEVICE, O_RDWR | O_NONBLOCK);
+#else
 	touchpanel_event_fd = open("/dev/input/touchscreen0", O_RDWR | O_NONBLOCK);
+#endif
 
 	if (touchpanel_event_fd < 0)
 	{


### PR DESCRIPTION
Without this, loading the module will fail.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>